### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: perl:5.28.1
+    steps:
+      - checkout
+      - run:
+          name: "Build"
+          command: |
+            perl Makefile.PL
+            make
+      - run:
+          name: "Run Test Suite"
+          command: |
+            make test
+

--- a/README
+++ b/README
@@ -10,3 +10,10 @@ Crypt::CFB - Encrypt Data in Cipher Feedback Mode
 
 Pure Perl implementation of Cipher Feedback Mode for almost
 arbitrary block ciphers and cryptographic hash functions.
+
+To build, run tests, and install:
+
+        perl Makefile.PL
+        make
+        make test
+        make install


### PR DESCRIPTION
* Run tests within CircleCI.
* Add standard CPAN module invocations for building, testing, and installing to README.